### PR TITLE
ripe berry counting and pickable boolean message

### DIFF
--- a/msg/GripperCam.msg
+++ b/msg/GripperCam.msg
@@ -7,3 +7,4 @@
 float64 calyx_distance
 # Number of berries
 int64 no_of_berries
+bool single_pickable_berry


### PR DESCRIPTION
Counts berries inside the gripper. Also counts just ripe berry. If there is one ripe berry it sets single_pickable_berry to True

Eventually we may want to consider the size, but need a basic calibration of where the berry needs to be in order to be picked.

Also @fcaponetto because the algorithm fps is much lower than the camera FPS, I think we need to create a service request for the gripper cam algorithm. The other option is to slow the camera fps to that of the algorithm or lower. However this would require us to know the algorithm fps which can change depending on what is in the image. 

EG of message output here: 
[video](https://drive.google.com/file/d/1AqpX3UjD_PF2ojEFUKEIDolJry5BSNtI/view?usp=sharing)