### PR TITLE
Updated Images to CUDA Version 11.1

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ version: '2.4'
 services:
     gripper_perception:
         # Need to docker login
-        image: repository.sagarobotics.com/detectron2.${DEVICE}:deploy
+        image: repository.sagarobotics.com/detectron2.${DEVICE}:cuda11_1
         container_name: detectron2_backend
         pull_policy: always
         network_mode: host
@@ -23,7 +23,7 @@ services:
 #        - ../../rasberry_perception:/catkin_ws/src/rasberry_perception
 
     robot_perception:
-        image: repository.sagarobotics.com/tensorrt_yolov4deepsort.${DEVICE}:deploy
+        image: repository.sagarobotics.com/tensorrt_yolov4deepsort.${DEVICE}:cuda11_1
         container_name: tensorrtdeepsort
         network_mode: host
         environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ version: '2.4'
 services:
     gripper_perception:
         # Need to docker login
-        image: repository.sagarobotics.com/detectron2.${DEVICE}:cuda11_1
+        image: repository.sagarobotics.com/detectron2.${DEVICE}:deploy
         container_name: detectron2_backend
         pull_policy: always
         network_mode: host
@@ -23,7 +23,7 @@ services:
 #        - ../../rasberry_perception:/catkin_ws/src/rasberry_perception
 
     robot_perception:
-        image: repository.sagarobotics.com/tensorrt_yolov4deepsort.${DEVICE}:cuda11_1
+        image: repository.sagarobotics.com/tensorrt_yolov4deepsort.${DEVICE}:deploy
         container_name: tensorrtdeepsort
         network_mode: host
         environment:

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -18,10 +18,10 @@
 ## Tag with:
 ##   docker tag repository.sagarobotics.com/base.gpu:local repository.sagarobotics.com/base.gpu:$(git show --format="%h" -s)
 
-FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
+FROM nvidia/cuda:11.1.1-cudnn8-runtime-ubuntu18.04
 
 ## Meta information
-LABEL cuda.version="10.2" maintainers="Saul Goldblatt <saul.goldblatt@sagarobotics.com>, Nikos Tsagkopoulos <ntsagkopoulos@sagarobotics.com>"
+LABEL cuda.version="11.1" maintainers="Saul Goldblatt <saul.goldblatt@sagarobotics.com>, Nikos Tsagkopoulos <ntsagkopoulos@sagarobotics.com>"
 
 ## Install ROS
 ENV ROS_DISTRO melodic
@@ -36,7 +36,8 @@ RUN rm /etc/apt/sources.list.d/* && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     DEBIAN_FRONTEND=noninteractive apt update
 RUN DEBIAN_FRONTEND=noninteractive apt install -y ros-${ROS_DISTRO}-catkin --no-install-recommends && \
-    DEBIAN_FRONTEND=noninteractive apt install -y ros-${ROS_DISTRO}-ros-base python-catkin-tools python3-venv python3-pip --no-install-recommends && \
+    DEBIAN_FRONTEND=noninteractive apt install -y ros-${ROS_DISTRO}-ros-base python-catkin-tools python3-venv python3-pip --no-install-recommends && \ 
+    DEBIAN_FRONTEND=noninteractive apt install -y build-essential && \
     DEBIAN_FRONTEND=noninteractive apt install -y python-rosdep --no-install-recommends && rosdep init && rosdep update
 
 ## Clone necessary repositories

--- a/docker/gpu/detectron2/Dockerfile
+++ b/docker/gpu/detectron2/Dockerfile
@@ -19,10 +19,10 @@
 ## Tag with:
 ##   docker tag repository.sagarobotics.com/detectron2.gpu:local repository.sagarobotics.com/detectron2.gpu:$(git show --format="%h" -s)
 
-FROM repository.sagarobotics.com/base.gpu:deploy
+FROM repository.sagarobotics.com/base.gpu:cuda11_1
 
 ## Meta information
-LABEL detectron2.version="0.4" maintainers="Saul Goldblatt <saul.goldblatt@sagarobotics.com>, Nikos Tsagkopoulos <ntsagkopoulos@sagarobotics.com>"
+LABEL detectron2.version="0.5" maintainers="Saul Goldblatt <saul.goldblatt@sagarobotics.com>, Nikos Tsagkopoulos <ntsagkopoulos@sagarobotics.com>"
 
 # Set FORCE_CUDA because during `docker build` cuda is not accessible
 ENV FORCE_CUDA="1"
@@ -48,14 +48,14 @@ RUN python3 -m venv detectron2_venv --clear && \
     pip install --no-cache-dir opencv-python numpy && \
     # At time of writing CUDA 10.2 is the native torch version
     #    pip install --no-cache-dir torch==1.5+cu102 torchvision==0.6+cu102 -f https://download.pytorch.org/whl/torch_stable.html && \
-    pip install torch==1.6.0 torchvision==0.7.0 && \
+    pip install torch==1.8.0+cu111 torchvision==0.9.0+cu111 torchaudio==0.8.0 -f https://download.pytorch.org/whl/torch_stable.html && \
     pip install --no-cache-dir 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI' && \
     pip install --no-cache-dir 'git+https://github.com/facebookresearch/fvcore' && \
     # Clone detectron2
     git clone https://github.com/facebookresearch/detectron2 && \
     # Install detectron2
     git clone https://github.com/facebookresearch/detectron2 detectron2_repo/ && \
-    python -m pip install detectron2==0.4 -f https://dl.fbaipublicfiles.com/detectron2/wheels/cu102/torch1.6/index.html && \
+    python -m pip install detectron2==0.5 -f https://dl.fbaipublicfiles.com/detectron2/wheels/cu111/torch1.8/index.html && \
     pip install --no-cache-dir rospkg
 
 ## Add backends. These files can be obtained from Raymond (rkirk@lincoln.ac.uk) and require citation when used.

--- a/docker/gpu/detectron2/Dockerfile
+++ b/docker/gpu/detectron2/Dockerfile
@@ -19,7 +19,7 @@
 ## Tag with:
 ##   docker tag repository.sagarobotics.com/detectron2.gpu:local repository.sagarobotics.com/detectron2.gpu:$(git show --format="%h" -s)
 
-FROM repository.sagarobotics.com/base.gpu:cuda11_1
+FROM repository.sagarobotics.com/base.gpu:deploy
 
 ## Meta information
 LABEL detectron2.version="0.5" maintainers="Saul Goldblatt <saul.goldblatt@sagarobotics.com>, Nikos Tsagkopoulos <ntsagkopoulos@sagarobotics.com>"

--- a/docker/gpu/tensorrtdeepsort/Dockerfile
+++ b/docker/gpu/tensorrtdeepsort/Dockerfile
@@ -11,9 +11,9 @@
 ## Tag with:
 ##   docker tag repository.sagarobotics.com/tensorrt_yolov4deepsort.gpu:local repository.sagarobotics.com/tensorrt_yolov4deepsort.gpu:$(git show --format="%h" -s)
 
-FROM nvcr.io/nvidia/tensorrt:20.09-py3
+FROM nvcr.io/nvidia/tensorrt:20.11-py3
 
-LABEL cuda.version="11.0" cudnn.version="8.0" tensorrt.version="7.1.3" maintainers="Robert Belshaw <rbelshaw@sagarobotics.com>, Nikos Tsagkopoulos <ntsagkopoulos@sagarobotics.com>"
+LABEL cuda.version="11.1" cudnn.version="8.0" tensorrt.version="7.2.1" maintainers="Robert Belshaw <rbelshaw@sagarobotics.com>, Nikos Tsagkopoulos <ntsagkopoulos@sagarobotics.com>"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update --no-install-recommends && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y ninja-build protobuf-compiler libprotobuf-dev python  python3-venv
@@ -35,7 +35,7 @@ WORKDIR /
 RUN python3.6 -m venv modularmot_venv --clear --system-site-packages && \
     . modularmot_venv/bin/activate && \
     pip install --no-cache-dir rospkg && \
-    dpkg -i /opt/tensorrt/python/*-tf_*.deb && \
+    . /opt/tensorrt/python/python_setup.sh && \
     pip install --no-cache-dir numpy && \
     pip install --no-cache-dir cython && \
     pip install --no-cache-dir cython-bbox && \
@@ -76,7 +76,7 @@ ENV PATH=/usr/local/cuda/bin${PATH:+:${PATH}}
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
 WORKDIR /
-RUN . modularmot_venv/bin/activate && /PerceptionApps/ModularMOT/modularmot/build_engine.py "/config.json"
+#RUN . modularmot_venv/bin/activate && /PerceptionApps/ModularMOT/modularmot/build_engine.py "/config.json"
 
 # Docker clean-up
 RUN rm -rf /var/lib/apt/lists/*

--- a/docker/gpu/tensorrtdeepsort/Dockerfile
+++ b/docker/gpu/tensorrtdeepsort/Dockerfile
@@ -15,6 +15,9 @@ FROM nvcr.io/nvidia/tensorrt:20.11-py3
 
 LABEL cuda.version="11.1" cudnn.version="8.0" tensorrt.version="7.2.1" maintainers="Robert Belshaw <rbelshaw@sagarobotics.com>, Nikos Tsagkopoulos <ntsagkopoulos@sagarobotics.com>"
 
+# Set FORCE_CUDA because during `docker build` cuda is not accessible
+ENV FORCE_CUDA="1"
+
 RUN DEBIAN_FRONTEND=noninteractive apt-get update --no-install-recommends && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y ninja-build protobuf-compiler libprotobuf-dev python  python3-venv
 
@@ -76,7 +79,7 @@ ENV PATH=/usr/local/cuda/bin${PATH:+:${PATH}}
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
 WORKDIR /
-#RUN . modularmot_venv/bin/activate && /PerceptionApps/ModularMOT/modularmot/build_engine.py "/config.json"
+RUN . modularmot_venv/bin/activate && /PerceptionApps/ModularMOT/modularmot/build_engine.py "/config.json"
 
 # Docker clean-up
 RUN rm -rf /var/lib/apt/lists/*

--- a/src/rasberry_perception/interfaces/detectron2.py
+++ b/src/rasberry_perception/interfaces/detectron2.py
@@ -34,7 +34,7 @@ def add_dataset_category_config(cfg):
 
 @DETECTION_REGISTRY.register_detection_backend("detectron2")
 class Detectron2Server(BaseDetectionServer):
-    _supported_version = "0.4"
+    _supported_version = "0.5"
 
     def __init__(self, config_file, service_name, model_file=None):
         try:


### PR DESCRIPTION
Changes 

1.  Update nvcr images to CUDA 11.1 versions
2. Update Detectron2 to 0.5 and torch to 1.8.1 for CUDA 11.1 support 
3. Now supports RTX3000 GPUS (Compute 86)